### PR TITLE
fixCmakeVersion(fix): Change minimum cmake version to 3.5

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -1,5 +1,5 @@
 # GENERAL SETTINGS
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.5)
 project(babel)
 
 set(APP_DIR ./)

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.5)
 project(Server)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Change minimum version of Cmake for the CMakeList files
(in order to avoid compatibility problem due to other OS's latest stable version of CMake)